### PR TITLE
Make Air/Car/Tank CBA XEH compatible again

### DIFF
--- a/addons/main/EMDisable.hpp
+++ b/addons/main/EMDisable.hpp
@@ -8,21 +8,22 @@ class CfgModSettings {
 	delete babe_EM;
 };
 
+class EventHandlers;
 class CfgVehicles {
 	class AllVehicles;
 	class Air: AllVehicles {
-		class EventHandlers {
+		class EventHandlers : EventHandlers {
 			delete babe_int_initEH;
 		};
 	};
 	class LandVehicle;
 	class Car: LandVehicle {
-		class EventHandlers {
+		class EventHandlers : EventHandlers {
 			delete babe_int_initEH;
 		};
 	};
 	class Tank: LandVehicle {
-		class EventHandlers {
+		class EventHandlers : EventHandlers {
 			delete babe_int_initEH;
 		};
 	};


### PR DESCRIPTION
So the issue is that the original mod defines EHs for Car/Air/Tank using a method that is not entirely compatible with how CBA does things. CBA [hooks up](https://github.com/CBATeam/CBA_A3/blob/master/addons/xeh/CfgVehicles.hpp#L2) its XEH into `class All` ([see also here](https://github.com/CBATeam/CBA_A3/blob/129d88255f3a7355f21939add381b657fc2ef7fa/addons/xeh/script_component.hpp#L42)), so we need to inherit it down the road in Air/Car/Tank.

An alternate approach would be to [just re-define the CBA class](https://github.com/CBATeam/CBA_A3/wiki/Extended-Event-Handlers-(new)#compatibility-without-dependance) if you prefer that way.

I tested my version only by directly modifying `config.cpp` because you seem to be using some PBO binarizer that allows you to define `CfgFunctions` / `CfgVehicles` multiple times in a single `.cpp` (by including `EMDisable.hpp`) which is normally invalid as far as the arma3.exe parser is concerned ("member already defined" error), so hopefully the submitted change works for you.

This gets rid of
```
 0:33:08 [CBA] (xeh) WARNING: Car does not support Extended Event Handlers! Addon: Enhanced-Movement-Rework
 0:33:08 [CBA] (xeh) WARNING: Tank does not support Extended Event Handlers! Addon: Enhanced-Movement-Rework
 0:33:08 [CBA] (xeh) WARNING: Air does not support Extended Event Handlers! Addon: Enhanced-Movement-Rework
```
(or similar) in the RPT log.

Thanks!
